### PR TITLE
fs: don't use GENERIC_READ with CreateFile when obtaining file info

### DIFF
--- a/ntfsutils/fs.py
+++ b/ntfsutils/fs.py
@@ -86,7 +86,7 @@ CloseHandle.argtypes = [HANDLE]
 CloseHandle.restype = BOOL
 
 def _getfileinfo(path, flags):
-    hfile = CreateFile(path, GENERIC_READ, FILE_SHARE_READ, None, OPEN_EXISTING, flags, None)
+    hfile = CreateFile(path, 0, FILE_SHARE_READ, None, OPEN_EXISTING, flags, None)
     if hfile is None:
         raise WinError()
     info = BY_HANDLE_FILE_INFORMATION()

--- a/ntfsutils/hardlink.py
+++ b/ntfsutils/hardlink.py
@@ -6,7 +6,8 @@
 
 __all__ = ["create", "samefile"]
 
-import fs
+import ntfsutils.fs as fs
+
 import ctypes
 from ctypes import WinError
 from ctypes.wintypes import BOOL

--- a/ntfsutils/junction.py
+++ b/ntfsutils/junction.py
@@ -8,8 +8,8 @@
 __all__ = ["create", "readlink", "unlink", "isjunction"]
 
 import os
-import fs
-from fs import CreateFile, GetFileAttributes, DeviceIoControl, CloseHandle
+import ntfsutils.fs as fs
+from ntfsutils.fs import CreateFile, GetFileAttributes, DeviceIoControl, CloseHandle
 
 import ctypes
 from ctypes import WinError, sizeof, byref

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -1,3 +1,5 @@
+import os
+
 from ntfsutils.fs import getfileinfo, getdirinfo
 from tests.common import TestDir
 
@@ -10,3 +12,12 @@ class TestFs(TestDir):
     def test_getfileinfo(self):
         with self.assertRaises(WindowsError) as cx:
             info = getfileinfo(self.DIR)
+
+        # simulate someone holding an exclussive access
+        locked = 'locked'
+        fd = os.open(locked, os.O_WRONLY | os.O_CREAT | os.O_EXCL)
+
+        # should not raise WinError
+        info = getfileinfo(locked)
+
+        os.close(fd)


### PR DESCRIPTION
We don't really need this flag, because we don't do any actual reading
except reading metadata. But using GENERIC_READ on file opened in exclusive
mode, results in 'OSError: [WinError 6] The handle is invalid' being raised,
which is caused by the GetFileInformationByHandle returing 0. This bug
is pretty easy to reproduce by just opening a file in excel and then trying
to feed it to getfileinfo().

This patch drops GENERIC_READ and also provides a test.